### PR TITLE
Modified seed to use absurdly long date ranges

### DIFF
--- a/bin/reseed-db
+++ b/bin/reseed-db
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Reseeding production database"
-RAILS_ENV=production rails db:reset DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-echo "Finished"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -105,7 +105,7 @@ elections << Election.create(
   position: "Present Election",
   deadline: DateTime.now - 1.week,
   start_time: DateTime.now - 2.day,
-  end_time: DateTime.now + 1.week,
+  end_time: DateTime.now + 99.year,
   session: session
 )
 
@@ -113,17 +113,17 @@ elections << Election.create(
 
 elections << Election.create(
   position: "Future Election 1",
-  deadline: DateTime.now + 1.month,
-  start_time: DateTime.now + 5.week,
-  end_time: DateTime.now + 6.week,
+  deadline: DateTime.now + 5.year,
+  start_time: DateTime.now + 6.week,
+  end_time: DateTime.now + 7.week,
   session: session
 )
 
 elections << Election.create(
   position: "Future Election 2",
-  deadline: DateTime.now + 1.week,
-  start_time: DateTime.now + 2.week,
-  end_time: DateTime.now + 15.day,
+  deadline: DateTime.now + 99.year,
+  start_time: DateTime.now + 100.year,
+  end_time: DateTime.now + 100.year,
   session: session
 )
 


### PR DESCRIPTION
Closes #6 

Adding cron job equivalent of heroku (heroku scheduler) requires credit card information. I couldn't find any work around this.

So, I have added absurdly long date ranges (for example, `present election` runs for 99 years) to 'fix' this.